### PR TITLE
Redundant patterns

### DIFF
--- a/panfeed/panfeed.py
+++ b/panfeed/panfeed.py
@@ -210,8 +210,9 @@ def parse_gff(file_name, feature_types=None):
 def iter_gene_clusters(panaroo, genome_data, up, down, patfilt):
     
     # go through each gene cluster
-    for idx, row in panaroo.iterrows():
-        logger.debug(f"Extracting sequences from {idx}")
+    all_ogs = panaroo.shape[0]
+    for i, (idx, row) in enumerate(panaroo.iterrows()):
+        logger.debug(f"Extracting sequences from {idx} ({i}/{all_ogs})")
         # output dict
         # key: strain
         # value: list of faidx sequence objects
@@ -258,7 +259,7 @@ def iter_gene_clusters(panaroo, genome_data, up, down, patfilt):
                     
                 except KeyError:
                     # e.g. refound genes are not in the GFF
-                    logger.warning(f"Could not find gene {gene} from {idx}")
+                    logger.warning(f"Could not find gene {gene} from {idx} in {strain}")
                     
                     continue
                 # access its gene sequence
@@ -515,6 +516,9 @@ def pattern_hasher(cluster_dict_iter, hash_pat, kmer_hash, genepres, patfilt):
                         continue
                     patterns.add(khash)
 
+                    if not len(patterns) % 1000:
+                        logger.debug(f"Observed patterns so far: {len(patterns)}")
+
                     patterntup = "\t".join(map(str, cluster_dict[kmer]))
                                     
                     memchunkhash_pat.write(f"{khash}\t{patterntup}\n")
@@ -529,6 +533,9 @@ def pattern_hasher(cluster_dict_iter, hash_pat, kmer_hash, genepres, patfilt):
                 if khash in patterns:
                     continue
                 patterns.add(khash)
+
+                if not len(patterns) % 1000:
+                    logger.debug(f"Observed patterns so far: {len(patterns)}")
 
                 patterntup = "\t".join(map(str, cluster_dict[kmer]))
                             


### PR DESCRIPTION
Avoid writing to file patterns that were already observed before. Tested with a large (N~900) pangenome did not result in a large memory footprint, so no reason not to have it