### PR TITLE
New argument to count k-mers in strains having the gene

### DIFF
--- a/panfeed/__main__.py
+++ b/panfeed/__main__.py
@@ -158,6 +158,13 @@ def get_options():
                                "presence absence pattern as the gene "
                                "cluster itself")
 
+    parser.add_argument("--consider-missing",
+                        action = "store_true",
+                        default = False,
+                        help = "Output NaN for strains that do not encode "
+                               "for a k-mer if the gene is missing "
+                               "(default: value is set to 0, as for the gene)")
+
     parser.add_argument("--multiple-files",
                         action = "store_true",
                         default = False,
@@ -239,6 +246,7 @@ def main():
                      stroi=stroi, 
                      multiple_files=args.multiple_files,
                      canon=not args.non_canonical,
+                     consider_missing_cluster=args.consider_missing,
                      output=args.output)
    
     patterns = set()


### PR DESCRIPTION
If a strain does not have the gene cluster we were giving it a value of zero for each k-mer, which in some applications might be undesirable (having a k-mer in the gene is different from not having the gene). The new argument `--consider-missing` will alter the presence/absence pattern and introduce a NaN for those strains that do not have the gene.