### PR TITLE
Add options to provide fasta files and compress outputs

### DIFF
--- a/panfeed/__main__.py
+++ b/panfeed/__main__.py
@@ -182,6 +182,12 @@ def get_options():
                         help = "Generate one set of outputs for each "
                                "gene cluster (default: one set of outputs)")
 
+    parser.add_argument("--compress",
+                        action = "store_true",
+                        default = False,
+                        help = "Compress output files with gzip "
+                               "(default: plain text)")
+
     parser.add_argument("--cores",
                         type = int,
                         default = 1,
@@ -238,7 +244,8 @@ def main():
                                              args.genes,
                                              args.presence_absence,
                                              args.output,
-                                             not args.multiple_files)
+                                             not args.multiple_files,
+                                             args.compress)
 
     logger.info("Preparing inputs")
     data = prep_data_n_fasta(filelist, fastalist,
@@ -261,7 +268,8 @@ def main():
                      multiple_files=args.multiple_files,
                      canon=not args.non_canonical,
                      consider_missing_cluster=args.consider_missing,
-                     output=args.output)
+                     output=args.output,
+                     compress=args.compress)
 
     patterns = set()
     func_w = partial(pattern_hasher,
@@ -273,7 +281,8 @@ def main():
                      maf=args.maf,
                      consider_missing_cluster=args.consider_missing,
                      output=args.output,
-                     patterns=patterns,)
+                     patterns=patterns,
+                     compress=args.compress)
 
     if args.cores > 2:
         # thanks to @SamStudio8 for the inspiration

--- a/panfeed/input.py
+++ b/panfeed/input.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import gzip
 import logging
 import numpy as np
 import pandas as pd
@@ -113,7 +114,8 @@ def clean_up_fasta(filelist, fastalist, output, fastadir):
             logger.warning(f"Could not delete {faidx_file}")
 
 
-def set_input_output(stroi_in, genes_in, presence_absence, output, single_file=True):
+def set_input_output(stroi_in, genes_in, presence_absence, output,
+                     single_file=True, compress=False):
     # determines the names of the input, output files 
    
     logger.debug(f"Loading pangenome file from panaroo ({presence_absence})")
@@ -153,8 +155,8 @@ def set_input_output(stroi_in, genes_in, presence_absence, output, single_file=T
     logger.debug(f"Creating output files within {output}")
     
     if single_file:
-        kmer_stroi = create_kmer_stroi(output)
-        hash_pat, kmer_hash = create_hash_files(output) 
+        kmer_stroi = create_kmer_stroi(output, compress)
+        hash_pat, kmer_hash = create_hash_files(output, compress) 
     else:
         # delayied opening of the files
         kmer_stroi = None
@@ -164,8 +166,12 @@ def set_input_output(stroi_in, genes_in, presence_absence, output, single_file=T
     return stroi, genes, kmer_stroi, hash_pat, kmer_hash, genepres
 
 
-def create_kmer_stroi(output):
-    kmer_stroi = open(os.path.join(output, "kmers.tsv"), "w")
+def create_kmer_stroi(output, compress=False):
+    if not compress:
+        kmer_stroi = open(os.path.join(output, "kmers.tsv"), "w")
+    else:
+        kmer_stroi = gzip.open(os.path.join(output, "kmers.tsv.gz"), "wt",
+                               compresslevel=9)
     
     #creates the header for the strains of interest output file
     kmer_stroi.write("cluster\tstrain\tfeature_id\tcontig\tfeature_strand\tcontig_start\tcontig_end\tgene_start\tgene_end\tstrand\tk-mer\n")
@@ -174,9 +180,15 @@ def create_kmer_stroi(output):
     return kmer_stroi
 
 
-def create_hash_files(output):
-    hash_pat = open(os.path.join(output, "hashes_to_patterns.tsv"), "w")
-    kmer_hash = open(os.path.join(output, "kmers_to_hashes.tsv"), "w")
+def create_hash_files(output, compress=False):
+    if not compress:
+        hash_pat = open(os.path.join(output, "hashes_to_patterns.tsv"), "w")
+        kmer_hash = open(os.path.join(output, "kmers_to_hashes.tsv"), "w")
+    else:
+        hash_pat = gzip.open(os.path.join(output, "hashes_to_patterns.tsv.gz"),
+                             "wt", compresslevel=9)
+        kmer_hash = gzip.open(os.path.join(output, "kmers_to_hashes.tsv.gz"),
+                              "wt", compresslevel=9)
 
     return hash_pat, kmer_hash
 

--- a/panfeed/panfeed.py
+++ b/panfeed/panfeed.py
@@ -22,7 +22,7 @@ def init_presabs_vector(n_strains, clusterpresab, missing_nan=False):
 
 def cluster_cutter(cluster_gen, klength, stroi,
                    multiple_files, canon, consider_missing_cluster,
-                   output):
+                   output, compress=False):
 #iterates through genes present in the cluster
 #shreds gene sequence into k-mers and adds them to the cluster dictionary
 #if a gene belongs to a strain of interest, additional info on the k-mer is saved
@@ -40,7 +40,7 @@ def cluster_cutter(cluster_gen, klength, stroi,
         path = os.path.join(output, idx)
         if not os.path.exists(path):
             os.mkdir(path)
-        kmer_stroi = create_kmer_stroi(path)
+        kmer_stroi = create_kmer_stroi(path, compress)
 
     cluster_dict = {}
 
@@ -131,7 +131,8 @@ def write_headers(hash_pat, kmer_hash, genepres):
 
 def pattern_hasher(cluster_dict_iter, kmer_stroi, hash_pat, kmer_hash,
                    genepres, patfilt, maf, output, patterns=None,
-                   consider_missing_cluster=False):
+                   consider_missing_cluster=False,
+                   compress=False):
     #iterates through the cluster dictionary output by cluster_cutter()
     #outputs the hashed patterns, patterns and k-mers to the output files
     #two files are created: hashed k-mer patterns to presence/absence patterns
@@ -159,7 +160,7 @@ def pattern_hasher(cluster_dict_iter, kmer_stroi, hash_pat, kmer_hash,
             path = os.path.join(output, idx)
             if not os.path.exists(path):
                 os.mkdir(path)
-            hash_pat, kmer_hash = create_hash_files(path)
+            hash_pat, kmer_hash = create_hash_files(path, compress)
             # must "flush" the already observed patterns file
             patterns = set()
 


### PR DESCRIPTION
Added two options:

- `-f`, `--fasta`, so that if GFF files don't have the nucleotide sequence panfeed can still be run (we enable ggCaller's output to be used this way)
- `--compress` to create gzipped files of all the outputs