### PR TITLE
Add the option to stop execution if anything is missing

### DIFF
--- a/panfeed/__main__.py
+++ b/panfeed/__main__.py
@@ -203,6 +203,12 @@ def get_options():
                                "reading queue limit = ql * cores"
                                "writing queue limit = ql")
 
+    parser.add_argument("--stop-on-missing",
+                        action = "store_true",
+                        default = False,
+                        help = "Crash if samples/chromosomes/genes "
+                               "are not found (default: throw warnings)")
+
     parser.add_argument("-v", action='count',
                         default=0,
                         help='Increase verbosity level')
@@ -261,7 +267,8 @@ def main():
                                 args.downstream,
                                 args.downstream_start_codon,
                                 not args.no_filter,
-                                genes)
+                                genes,
+                                args.stop_on_missing)
     iter_o = partial(cluster_cutter,
                      klength=klength,
                      stroi=stroi,

--- a/panfeed/input.py
+++ b/panfeed/input.py
@@ -263,7 +263,7 @@ def parse_gff(file_name, feature_types=None):
 
 
 def iter_gene_clusters(panaroo, genome_data, up, down, down_start_codon, patfilt,
-                       gene_list=None):
+                       gene_list=None, raise_missing=False):
     # check if we have genome data for all
     # strains in the pangenome
     # if not give a warning
@@ -274,6 +274,8 @@ def iter_gene_clusters(panaroo, genome_data, up, down, down_start_codon, patfilt
                        'in the pangenome table but not in the GFF directory')
         for strain in missing_strains:
             logger.debug(f'Missing GFF file: {strain}')
+        if raise_missing:
+            raise KeyError(f'Missing {len(missing_strains)} from the GFF directory')
 
     # go through each gene cluster
     all_ogs = panaroo.shape[0]
@@ -324,6 +326,17 @@ def iter_gene_clusters(panaroo, genome_data, up, down, down_start_codon, patfilt
                 except KeyError:
                     # e.g. refound genes are not in the GFF
                     logger.warning(f"Could not find gene {gene} from {idx} in {strain}")
+                    if raise_missing:
+                        raise KeyError(f"Could not find gene {gene} from {idx} in {strain}")
+                    continue
+                # double check if the chromosome is in the fasta file
+                try:
+                    sequences[feat.chromosome]
+                except KeyError:
+                    # e.g. refound genes are not in the GFF
+                    logger.warning(f"Could not find chromosome {feat.chromosome} in {strain}")
+                    if raise_missing:
+                        raise KeyError(f"Could not find chromosome {feat.chromosome} in {strain}")
                     continue
                 
                 # corner case: upstream offset is over the contig's edge


### PR DESCRIPTION
Samples, genes or chromosomes might be missing from the inputs; so far panfeed would throw a warning and continue. This change introduces an option to stop execution if anything is missing.

This change also introduces a check on the presence of a chromosome, which may be missing from the assembly but indicated in the gff file.